### PR TITLE
Ensures only a single optimization flag is set in nvcc_wrapper

### DIFF
--- a/nvcc_wrapper
+++ b/nvcc_wrapper
@@ -98,6 +98,7 @@ do
    # Ensure we only have one optimization flag because NVCC doesn't allow muliple
   -O*)
     if [ $optimization_applied -eq 0 ]; then
+       echo "nvcc_wrapper - *warning* you have set multiple optimization flags (-O*), only the first is used because nvcc can only accept a single optimization setting."
        shared_args="$shared_args $1"
        optimization_applied=1
     fi

--- a/nvcc_wrapper
+++ b/nvcc_wrapper
@@ -71,6 +71,9 @@ first_xcompiler_arg=1
 
 temp_dir=${TMPDIR:-/tmp}
 
+# Check if we have an optimization argument already
+optimization_applied=0
+
 #echo "Arguments: $# $@"
 
 while [ $# -gt 0 ]
@@ -92,8 +95,15 @@ do
   *.cpp|*.cxx|*.cc|*.C|*.c++|*.cu)
     cpp_files="$cpp_files $1"
     ;;
+   # Ensure we only have one optimization flag because NVCC doesn't allow muliple
+  -O*)
+    if [ $optimization_applied -eq 0 ]; then
+       shared_args="$shared_args $1"
+       optimization_applied=1
+    fi
+    ;;
   #Handle shared args (valid for both nvcc and the host compiler)
-  -O*|-D*|-c|-I*|-L*|-l*|-g|--help|--version|-E|-M|-shared)
+  -D*|-c|-I*|-L*|-l*|-g|--help|--version|-E|-M|-shared)
     shared_args="$shared_args $1"
     ;;
   #Handle shared args that have an argument


### PR DESCRIPTION
This change ensures only a single optimization flag is passed through to nvcc. If multiple flags are provided to the compiler it will error out causing nothing to be compiled. `nvcc_wrapper` now prints a warning and selects the _FIRST_ flag encountered to be passed to `nvcc`.
