### PR TITLE
more known nvcc arguments for nvcc_wrapper

### DIFF
--- a/nvcc_wrapper
+++ b/nvcc_wrapper
@@ -121,6 +121,10 @@ do
   -gencode*|--dryrun|--verbose|--keep|--keep-dir*|-G|--relocatable-device-code*|-lineinfo|-expt-extended-lambda|--resource-usage|-Xptxas*)
     cuda_args="$cuda_args $1"
     ;;
+  #Handle more known nvcc args
+  --expt-extended-lambda|--expt-relaxed-constexpr)
+    cuda_args="$cuda_args $1"
+    ;;
   #Handle known nvcc args that have an argument
   -rdc|-maxrregcount|--default-stream)
     cuda_args="$cuda_args $1 $2"


### PR DESCRIPTION
These two flags are used while compiling a Sandia code, it would help if nvcc_wrapper would recognize them (currently a custom nvcc_wrapper is used).
