### PR TITLE
Add support for ninja depfile generation

### DIFF
--- a/nvcc_wrapper
+++ b/nvcc_wrapper
@@ -72,6 +72,7 @@ dry_run=0
 
 # Skip NVCC compilation and use host compiler directly
 host_only=0
+host_only_args=""
 
 # Enable workaround for CUDA 6.5 for pragma ident 
 replace_pragma_ident=0
@@ -86,6 +87,11 @@ optimization_applied=0
 
 # Check if we have -std=c++X  or --std=c++X already
 stdcxx_applied=0
+
+# Run nvcc a second time to generate dependencies if needed
+depfile_separate=0
+depfile_output_arg=""
+depfile_target_arg=""
 
 #echo "Arguments: $# $@"
 
@@ -130,8 +136,19 @@ do
     output_arg="$output_arg $1 $2"
     shift
     ;;
+  # Handle depfile arguments.  We map them to a separate call to nvcc.
+  -MD|-MMD)
+    depfile_separate=1
+    host_only_args="$host_only_args $1"
+    ;;
+  -MF)
+    depfile_output_arg="-o $2"
+    host_only_args="$host_only_args $1 $2"
+    shift
+    ;;
   -MT)
-    shared_args="$shared_args $1 $2"
+    depfile_target_arg="$1 $2"
+    host_only_args="$host_only_args $1 $2"
     shift
     ;;
   #Handle known nvcc args
@@ -256,7 +273,7 @@ if [ $first_xcompiler_arg -eq 0 ]; then
 fi
 
 #Compose host only command
-host_command="$host_compiler $shared_args $compile_arg $output_arg $xcompiler_args $host_linker_args $shared_versioned_libraries_host"
+host_command="$host_compiler $shared_args $host_only_args $compile_arg $output_arg $xcompiler_args $host_linker_args $shared_versioned_libraries_host"
 
 #nvcc does not accept '#pragma ident SOME_MACRO_STRING' but it does accept '#ident SOME_MACRO_STRING'
 if [ $replace_pragma_ident -eq 1 ]; then
@@ -288,12 +305,21 @@ else
   host_command="$host_command $object_files"
 fi
 
+if [ $depfile_separate -eq 1 ]; then
+  # run nvcc a second time to generate dependencies (without compiling)
+  nvcc_depfile_command="$nvcc_command -M $depfile_target_arg $depfile_output_arg"
+else
+  nvcc_depfile_command=""
+fi
+
 nvcc_command="$nvcc_command $compile_arg $output_arg"
 
 #Print command for dryrun
 if [ $dry_run -eq 1 ]; then
   if [ $host_only -eq 1 ]; then
     echo $host_command
+  elif [ -n "$nvcc_depfile_command" ]; then
+    echo $nvcc_command "&&" $nvcc_depfile_command
   else
     echo $nvcc_command
   fi
@@ -303,6 +329,8 @@ fi
 #Run compilation command
 if [ $host_only -eq 1 ]; then
   $host_command
+elif [ -n "$nvcc_depfile_command" ]; then
+  $nvcc_command && $nvcc_depfile_command
 else
   $nvcc_command
 fi

--- a/nvcc_wrapper
+++ b/nvcc_wrapper
@@ -39,6 +39,12 @@ cuda_args=""
 # Arguments for both NVCC and Host compiler
 shared_args=""
 
+# Argument -c
+compile_arg=""
+
+# Argument -o <obj>
+output_arg=""
+
 # Linker arguments
 xlinker_args=""
 
@@ -112,11 +118,19 @@ do
     fi
     ;;
   #Handle shared args (valid for both nvcc and the host compiler)
-  -D*|-c|-I*|-L*|-l*|-g|--help|--version|-E|-M|-shared)
+  -D*|-I*|-L*|-l*|-g|--help|--version|-E|-M|-shared)
     shared_args="$shared_args $1"
     ;;
-  #Handle shared args that have an argument
-  -o|-MT)
+  #Handle compilation argument
+  -c)
+    compile_arg="$1"
+    ;;
+  #Handle output argument
+  -o)
+    output_arg="$output_arg $1 $2"
+    shift
+    ;;
+  -MT)
     shared_args="$shared_args $1 $2"
     shift
     ;;
@@ -242,7 +256,7 @@ if [ $first_xcompiler_arg -eq 0 ]; then
 fi
 
 #Compose host only command
-host_command="$host_compiler $shared_args $xcompiler_args $host_linker_args $shared_versioned_libraries_host"
+host_command="$host_compiler $shared_args $compile_arg $output_arg $xcompiler_args $host_linker_args $shared_versioned_libraries_host"
 
 #nvcc does not accept '#pragma ident SOME_MACRO_STRING' but it does accept '#ident SOME_MACRO_STRING'
 if [ $replace_pragma_ident -eq 1 ]; then
@@ -273,6 +287,8 @@ if [ "$cpp_files" ]; then
 else
   host_command="$host_command $object_files"
 fi
+
+nvcc_command="$nvcc_command $compile_arg $output_arg"
 
 #Print command for dryrun
 if [ $dry_run -eq 1 ]; then


### PR DESCRIPTION
The nvcc compiler does not support `-c -o $obj -MD -MT $obj -MF $obj.d` for compiling and generating dependencies at the same time.  However, it does support `-M -MT $obj -o $obj.d` for dependency generation without compiling.  Recognize the `-MD` flag and invoke nvcc a second time after compiling in order to produce the dependency file.

Without this, passing `-MD` to nvcc goes to the host compiler which generates dependencies using the temporary input files that nvcc generates internally.  This causes the dependency file to reference the
temporary files that no longer exist.  If the build system (e.g. Ninja) honors the dependency file then it sees that the temporary file is missing and re-runs the compilation on every build.

Issue: trilinos/Trilinos#321
