### PR TITLE
Strip -Woverloaded-virtual

### DIFF
--- a/nvcc_wrapper
+++ b/nvcc_wrapper
@@ -140,6 +140,9 @@ do
   #strip of pedantic because it produces endless warnings about #LINE added by the preprocessor
   -pedantic|-Wpedantic|-ansi)
     ;;
+  #strip of -Woverloaded-virtual to avoid "cc1: warning: command line option ‘-Woverloaded-virtual’ is valid for C++/ObjC++ but not for C"
+  -Woverloaded-virtual)
+    ;;
   #strip -Xcompiler because we add it
   -Xcompiler)
     if [ $first_xcompiler_arg -eq 1 ]; then


### PR DESCRIPTION
see the comment in the script file about why.
I see that warning a lot currently when compiling Trilinos with nvcc_wrapper.