### PR TITLE
Add debug print to nvcc_wrapper when env var NVCC_WRAPPER_SHOW_COMMANDS_BEING_RUN=1 (#19)

### DIFF
--- a/nvcc_wrapper
+++ b/nvcc_wrapper
@@ -391,10 +391,19 @@ fi
 
 #Run compilation command
 if [ $host_only -eq 1 ]; then
+  if [ "$NVCC_WRAPPER_SHOW_COMMANDS_BEING_RUN" == "1" ] ; then
+    echo "$host_command"
+  fi
   $host_command
 elif [ -n "$nvcc_depfile_command" ]; then
+  if [ "$NVCC_WRAPPER_SHOW_COMMANDS_BEING_RUN" == "1" ] ; then
+    echo "$nvcc_command && $nvcc_depfile_command"
+  fi
   $nvcc_command && $nvcc_depfile_command
 else
+  if [ "$NVCC_WRAPPER_SHOW_COMMANDS_BEING_RUN" == "1" ] ; then
+    echo "$nvcc_command"
+  fi
   $nvcc_command
 fi
 error_code=$?


### PR DESCRIPTION
This allows you to see the actually nvcc commands that are run by the
nvcc_wrapper while it is running.  This is very useful for debugging problems
with the nvcc_wrapper script and problem with nvcc itself.

I needed this to help debug issues with resoruce file handling with Ninja for
trilinos/Trilinos#3069.