### PR TITLE
Fix linker flag filter

### DIFF
--- a/nvcc_wrapper
+++ b/nvcc_wrapper
@@ -193,7 +193,7 @@ do
     shift
     ;;
   #Handle args that should be sent to the linker
-  -Wl*)
+  -Wl,*)
     xlinker_args="$xlinker_args -Xlinker ${1:4:${#1}}"
     host_linker_args="$host_linker_args ${1:4:${#1}}"
     ;;


### PR DESCRIPTION
The old filter was interpreting the
warning flag "-Wlogical-op" as a linker flag.
We need to require that there be a comma after
the "l".