### PR TITLE
nvcc_wrapper: Handle -+ for XL

### DIFF
--- a/nvcc_wrapper
+++ b/nvcc_wrapper
@@ -174,6 +174,16 @@ do
     fi
     shift
     ;;
+  #Handle -+ (same as -x c++, specifically used for xl compilers, but mutually exclusive with -x. So replace it with -x c++)
+  -+)
+    if [ $first_xcompiler_arg -eq 1 ]; then
+      xcompiler_args="-x,c++"
+      first_xcompiler_arg=0
+    else
+      xcompiler_args="$xcompiler_args,-x,c++"
+    fi
+    shift
+    ;;
   #Handle -ccbin (if its not set we can set it to a default value)
   -ccbin)
     cuda_args="$cuda_args $1 $2"


### PR DESCRIPTION
XL compilers have an option called '-+' that equates to '-x c++'
(directly from the manpage).  However, passing '-+' with any '-x' option
causes an error.  So, translate '-+' to '-x c++'.  This is of particular
relevance because CMake adds '-+' to CXX compiler lines using XL.

This should fix https://github.com/kokkos/kokkos/issues/897 as well
(though it is already technically closed).