### PR TITLE
nvcc_wrapper: Fix incorrect parser shift

### DIFF
--- a/nvcc_wrapper
+++ b/nvcc_wrapper
@@ -228,7 +228,6 @@ do
     else
       xcompiler_args="$xcompiler_args,-x,c++"
     fi
-    shift
     ;;
   #Handle -ccbin (if its not set we can set it to a default value)
   -ccbin)


### PR DESCRIPTION
The -+ option that I added was incorrectly shifting twice, resulting in
the loss of the next discrete command-line argument.