### PR TITLE
Add Auto-Override of -O to handle issue #28

### DIFF
--- a/nvcc_wrapper
+++ b/nvcc_wrapper
@@ -119,7 +119,11 @@ do
     if [ $optimization_applied -eq 1 ]; then
        echo "nvcc_wrapper - *warning* you have set multiple optimization flags (-O*), only the first is used because nvcc can only accept a single optimization setting."
     else
-       shared_args="$shared_args $1"
+       if [ "$1" = "-O" ]; then
+         shared_args="$shared_args -O2"
+       else
+         shared_args="$shared_args $1"
+       fi
        optimization_applied=1
     fi
     ;;


### PR DESCRIPTION
Change `-O` command line option, auto-upgrade to `-O2` which is consistent with compiler behavior.