### PR TITLE
Support accepting -Xnvlink options.

### DIFF
--- a/nvcc_wrapper
+++ b/nvcc_wrapper
@@ -183,7 +183,7 @@ do
     cuda_args="$cuda_args $1"
     ;;
   #Handle known nvcc args that have an argument
-  -rdc|-maxrregcount|--default-stream)
+  -rdc|-maxrregcount|--default-stream|-Xnvlink)
     cuda_args="$cuda_args $1 $2"
     shift
     ;;


### PR DESCRIPTION
@crtrott @ibaned 

This lets us use "-Xnvlink --suppress-stack-size-warning" to get rid of the spurious warnings when we build virtual functions on the GPU with RDC.