### PR TITLE
Support -Wext-lambda-captures-this option for cuda 11

### DIFF
--- a/nvcc_wrapper.in
+++ b/nvcc_wrapper.in
@@ -240,6 +240,9 @@ do
   #strip of -Woverloaded-virtual to avoid "cc1: warning: command line option ‘-Woverloaded-virtual’ is valid for C++/ObjC++ but not for C"
   -Woverloaded-virtual)
     ;;
+  -Wext-lambda-captures-this|--Wext-lambda-captures-this)
+    cuda_args="$cuda_args $1"
+    ;;
   #strip -Xcompiler because we add it
   -Xcompiler)
     if [ $first_xcompiler_arg -eq 1 ]; then


### PR DESCRIPTION
See https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#generic-tool-options-Wext-lambda-captures-this
